### PR TITLE
Pass through shapely import

### DIFF
--- a/contours/core.py
+++ b/contours/core.py
@@ -14,14 +14,17 @@ import numpy as np
 
 # Attempt to import shapely and enable speedups.
 try:
-    import shapely.speedups
-    if shapely.speedups.available:
-        shapely.speedups.enable()
-finally:
     try:
-        from shapely.geometry import LineString, LinearRing, Polygon
-    except ImportError:
-        pass
+        import shapely.speedups
+        if shapely.speedups.available:
+            shapely.speedups.enable()
+    finally:
+        try:
+            from shapely.geometry import LineString, LinearRing, Polygon
+        except ImportError:
+            pass
+except:
+    pass
 
 
 class MPLPATHCODE(IntEnum):


### PR DESCRIPTION
I wanted to depend on this package for the manim repo, but this import made shapely an obligatory package alongside. I didn't use shapely for that part of the codebase, so this bypasses that import.